### PR TITLE
Improve inheritance support

### DIFF
--- a/src/Uno.CodeGen.ClassLifecycle/LifecycleMethods.cs
+++ b/src/Uno.CodeGen.ClassLifecycle/LifecycleMethods.cs
@@ -24,6 +24,8 @@ namespace Uno.CodeGen.ClassLifecycle
 	internal class LifecycleMethods
 	{
 		public INamedTypeSymbol Owner { get; }
+		public IEnumerable<LifecycleMethods> Bases { get; set; }
+
 		public ICollection<IMethodSymbol> AllMethods { get; }
 		public ICollection<IMethodSymbol> Constructors { get; }
 		public ICollection<IMethodSymbol> Disposes { get; }

--- a/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
+++ b/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
@@ -11,7 +11,7 @@
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>
 		<Description>This package provides a generator which generates the class life cycle method using the attributes from Uno.ClassLifecycle.
-This package is part of the Uno.CodeGen to generate object life cycle methods in your project.</Description>
+This package is part of the Uno.CodeGen to generate classes lifecycle methods in your project.</Description>
 		<RootNamespace>Uno</RootNamespace>
 		<Copyright>Copyright (C) 2015-2018 nventive inc. - all rights reserved</Copyright>
 		<PackageProjectUrl>https://github.com/nventive/Uno.CodeGen</PackageProjectUrl>


### PR DESCRIPTION
- Constructor: Do not ignore the required parameters of the base class when generating the default constructor
- Dispose: If base class is in the same project, detect if the base class will implement IDisposable