### PR TITLE
Fix possible null ref in ClassLifecycle generation

### DIFF
--- a/src/Uno.ClassLifecycle/Uno.ClassLifecycle.csproj
+++ b/src/Uno.ClassLifecycle/Uno.ClassLifecycle.csproj
@@ -20,4 +20,5 @@ This package is part of the Uno.CodeGen to generate object life cycle methods in
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
 	</PropertyGroup>
 
+	<Import Project="..\Uno.Common.props" />
 </Project>

--- a/src/Uno.CodeGen.ClassLifecycle/ClassLifecycleGenerator.cs
+++ b/src/Uno.CodeGen.ClassLifecycle/ClassLifecycleGenerator.cs
@@ -53,7 +53,7 @@ namespace Uno.CodeGen.ClassLifecycle
 			_finalizerAttribute = context.Compilation.GetTypeByMetadataName("Uno.FinalizerMethodAttribute");
 			
 			_iDisposable_Dispose = context.Compilation.GetTypeByMetadataName("System.IDisposable").GetMembers("Dispose").Single();
-			_extentibleDisposable_RegisterExtension = context.Compilation.GetTypeByMetadataName("Uno.Disposables.IExtensibleDisposable").GetMembers("RegisterExtension").SingleOrDefault();
+			_extentibleDisposable_RegisterExtension = context.Compilation.GetTypeByMetadataName("Uno.Disposables.IExtensibleDisposable")?.GetMembers("RegisterExtension").SingleOrDefault();
 
 			foreach (var methods in GetLifecycleMethods())
 			{
@@ -356,7 +356,9 @@ namespace Uno.CodeGen.ClassLifecycle
 				.JoinByEmpty();
 
 			var iDisposableImplementation = methods.Owner.FindImplementationForInterfaceMember(_iDisposable_Dispose);
-			var iExtensibleDisposableImplementation = methods.Owner.FindImplementationForInterfaceMember(_extentibleDisposable_RegisterExtension) as IMethodSymbol;
+			var iExtensibleDisposableImplementation = _extentibleDisposable_RegisterExtension == null
+				? default(IMethodSymbol)
+				: methods.Owner.FindImplementationForInterfaceMember(_extentibleDisposable_RegisterExtension) as IMethodSymbol;
 			var (patternKind, patternMethod) = methods.Owner.GetDisposablePatternImplementation();
 			var (disposeKind, disposeMethod) = methods.Owner.GetDisposableImplementation();
 

--- a/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
+++ b/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
@@ -19,6 +19,8 @@ This package is part of the Uno.CodeGen to generate classes lifecycle methods in
 		<RepositoryUrl>https://github.com/nventive/Uno.CodeGen</RepositoryUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
 	</PropertyGroup>
+	
+	<Import Project="..\Uno.Common.props" />
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net46'">
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" PrivateAssets="all" />

--- a/src/Uno.CodeGen/Uno.CodeGen.csproj
+++ b/src/Uno.CodeGen/Uno.CodeGen.csproj
@@ -13,6 +13,8 @@
 		<Description>This package provides tooling for code generation.</Description>
 		<Copyright>Copyright (C) 2015-2018 nventive inc. - all rights reserved</Copyright>
 	</PropertyGroup>
+	
+	<Import Project="..\Uno.Common.props" />
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net46'">
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" PrivateAssets="all" />

--- a/src/Uno.Common.props
+++ b/src/Uno.Common.props
@@ -1,81 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SolutionDir)\crosstargeting_override.props" Condition="exists('$(SolutionDir)\crosstargeting_override.props')" />
   
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45' or ('$(ProjectTypeGuids)'=='' and ('$(TargetFrameworkVersion)'=='v4.5' or '$(TargetFrameworkVersion)'=='v4.5.1'))">
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_GEOCOORDINATE_WATCHER;HAS_GEOCOORDINATE;HAS_COMPILED_REGEX;USE_FAST_REPLAYONE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_SEMAPHORE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_FILE_IO</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_THREADS</UnoDefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0' or '$(ProjectTypeGuids)'=='{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}'">
-    <UnoDefineConstants>$(UnoDefineConstants);WINDOWS_UAP;WINDOWS_UWP</UnoDefineConstants>
+  <Target Name="_OverrideNuget"
+		  AfterTargets="AfterBuild"
+		  DependsOnTargets="BuiltProjectOutputGroup"
+		  Condition="'$(NugetOverrideVersion)'!=''">
 
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_WINDOWS_UI;HAS_TOP_APPBAR;HAS_BOTTOM_APPBAR</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_VIEWSIZE_PREFERENCE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_GEOPOSITION</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);USE_SINGLE_ITEM_COLLECTIONCHANGED</UnoDefineConstants>
+		<PropertyGroup>
+			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
+			<_TargetNugetFolder Condition="'$(IsTool)'=='true' AND '$(TargetFramework)' == 'net46'">$(USERPROFILE)\.nuget\packages\$(AssemblyName)\$(NugetOverrideVersion)\tools</_TargetNugetFolder>
+			<_TargetNugetFolder Condition="'$(IsTool)'!='true'">$(USERPROFILE)\.nuget\packages\$(AssemblyName)\$(NugetOverrideVersion)\lib\$(_OverrideTargetFramework)</_TargetNugetFolder>
+		</PropertyGroup>
+		<ItemGroup>
+			<_OutputFiles Include="@(BuiltProjectOutputGroupOutput)" />
+			<_OutputFilesPDB Include="@(_OutputFiles->'%(RootDir)\%(Directory)\%(RecursiveDir)%(Filename).pdb')" Condition="Exists('@(BuiltProjectOutputGroupOutput->'%(RootDir)\%(Directory)\%(RecursiveDir)%(Filename).pdb')')" />
+		</ItemGroup>
+		
+		<MakeDir Directories="$(_TargetNugetFolder)" Condition="'$(_TargetNugetFolder)'!=''" />
 
-    <UnoDefineConstants>$(UnoDefineConstants);NETFX_CORE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);METRO</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);WINRT</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_WINRT_FILEIO;HAS_QUERYOPTIONS;HAS_CRIPPLEDREFLECTION;HAS_TYPEINFO;USE_FAST_REPLAYONE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_ISTORAGEFILE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_NATIVE_SYSTEMINFO</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_ISTORAGEFILE_ADVANCED</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_GEOLOCATOR</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_SEMAPHORE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_HTTPCLIENT</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_DATACONTEXTCHANGED</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_HARDWARE_BUTTONS</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_TYPEINFO_EXTENSIONS</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_CAMERA_CAPTURE_UI</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_FILE_IO</UnoDefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10' or '$(ProjectTypeGuids)'=='{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}'">
-    <UnoDefineConstants>$(UnoDefineConstants);XAMARIN;XAMARIN_IOS</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_COMPILED_REGEX;HAS_CRIPPLEDREFLECTION;USE_FAST_REPLAYONE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_QUERY_OPTIONS</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_BROKEN_SEMAPHORE_SLIM</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_SEMAPHORE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_NO_CONCURRENT_DICT</UnoDefineConstants>
-    <!-- Performance is worse than Sync Dic-->
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_FILE_IO</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_THREADS</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);NO_DNSENDPOINT</UnoDefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid60' or '$(ProjectTypeGuids)'=='{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}'">
-    <UnoDefineConstants>$(UnoDefineConstants);XAMARIN;XAMARIN_ANDROID</UnoDefineConstants>
+		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" Condition="'$(_TargetNugetFolder)'!=''" />
+		<Message Importance="high" Text="DO NOT override nuget package when tool built for: $(_OverrideTargetFramework)" Condition="'$(_TargetNugetFolder)'==''" />
 
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_COMPILED_REGEX;HAS_CRIPPLEDREFLECTION;USE_FAST_REPLAYONE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_BROKEN_SEMAPHORE_SLIM</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_SEMAPHORE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_NO_WINDOWS_DISPATCHER</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_HTTPCLIENT</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_NO_CONCURRENT_DICT</UnoDefineConstants>
-    <!-- Performance is worse than Sync Dic-->
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_FILE_IO</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_THREADS</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);NO_DNSENDPOINT</UnoDefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">
-    <UnoDefineConstants>$(UnoDefineConstants);XAMARIN;XAMARIN_ANDROID</UnoDefineConstants>
-
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_COMPILED_REGEX;HAS_CRIPPLEDREFLECTION;USE_FAST_REPLAYONE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_BROKEN_SEMAPHORE_SLIM</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_SEMAPHORE</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_NO_WINDOWS_DISPATCHER</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_HTTPCLIENT</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_NO_CONCURRENT_DICT</UnoDefineConstants>
-    <!-- Performance is worst than Sync Dic-->
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_FILE_IO</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);HAS_THREADS</UnoDefineConstants>
-    <UnoDefineConstants>$(UnoDefineConstants);NO_DNSENDPOINT</UnoDefineConstants>
-  </PropertyGroup>
-  <Target Name="_UnoDefineConstantsDefines" BeforeTargets="BeforeCompile;XamlPreCompile;CoreCompile">
-    <!-- Merge the AppTasksDefineConstants with the existing constants -->
-    <CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-      <Output TaskParameter="Value" PropertyName="DefineConstants" />
-    </CreateProperty>
-  </Target>
+		<Copy 
+			SourceFiles="@(_OutputFiles)"
+			DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')"
+			Condition="'$(_TargetNugetFolder)'!=''"	/>
+		<Copy 
+			SourceFiles="@(_OutputFilesPDB)"
+			DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')"
+			Condition="'$(_TargetNugetFolder)'!=''" />
+	</Target>
 </Project>

--- a/src/Uno.Equality/Uno.Equality.csproj
+++ b/src/Uno.Equality/Uno.Equality.csproj
@@ -19,5 +19,7 @@ This package is part of the Uno.CodeGen to generate equality members in your pro
 		<RepositoryUrl>https://github.com/nventive/Uno.CodeGen</RepositoryUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
 	</PropertyGroup>
-
+	
+	<Import Project="..\Uno.Common.props" />
+	
 </Project>

--- a/src/Uno.Immutables/Uno.Immutables.csproj
+++ b/src/Uno.Immutables/Uno.Immutables.csproj
@@ -19,6 +19,8 @@ This package is part of the Uno.CodeGen to generate immutable entities in your p
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
 		<Copyright>Copyright (C) 2015-2018 nventive inc. - all rights reserved</Copyright>
 	</PropertyGroup>
+	
+	<Import Project="..\Uno.Common.props" />
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Equality\Uno.Equality.csproj" />

--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -1,24 +1,20 @@
 <Project ToolsVersion="15.0">
-  <PropertyGroup>
-    <!--
-      This file is used to control the platforms compiled by visual studio, and 
-      allow for a faster build when testing for a single platform.
-      
-      e.g. when compiling for unit tests, set the TargetPlatforms to net46.
-      
-			Instructions:
+  <!--
+		This file is used to control the Uno.CodeGen's compilation in visual studio, and 
+		allow for a faster build / test cycle when debugging / testing Uno.CodeGen.
+		
+		Instructions:
 			1) Copy this file and remove the ".sample" extension
-			2) Adjust the TargetFrameworks properties below
+			2) Adjust the properties below
 			3) Make sure to do a Rebuild, so that nuget restores the proper packages for the new target
+	-->
 
-			Original frameworks: Xamarin.iOS10;MonoAndroid71;uap10.0;net46
+	<PropertyGroup>
+		<!-- 
+			This property allows the override of the nuget local cache.
+			Set it to the version you want to override, used in another app.
 		-->
-    <TargetFrameworks>net46;Xamarin.iOS10</TargetFrameworks>
-
-    <!-- 
-    This property allows the override of the nuget local cache.
-    Set it to the version you want to override, used in another app.
-    -->
-    <!--<UmbrellaNugetOverrideVersion>2.23.2-dev.667</UmbrellaNugetOverrideVersion>-->
-  </PropertyGroup>
+		<!--<NugetOverrideVersion>1.20.0-dev.55</NugetOverrideVersion>-->
+	
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
* Fix possible null ref in ClassLifecycle generation if the Uno.Core package is not referenced by the target project
* Add configuration to ease debugging of the code gen in external projects