### PR TITLE
Immutables: static properties were not excluded

### DIFF
--- a/src/Uno.CodeGen.Tests/Given_ImmutableEntity.cs
+++ b/src/Uno.CodeGen.Tests/Given_ImmutableEntity.cs
@@ -237,4 +237,17 @@ namespace Uno.CodeGen.Tests
 		[EqualityComparerOptions(CollectionMode = CollectionComparerMode.Unsorted)]
 		public byte[] UnsortedBytes { get; }
 	}
+
+	[GeneratedImmutable]
+	public partial class ImmutableWithStaticProperties
+	{
+		public static ImmutableWithStaticProperties Version1 { get; } = Default;
+
+		public static ImmutableWithStaticProperties Version2 { get; } = Default.WithVersion(2);
+
+		public static ImmutableWithStaticProperties Version3 { get; } = Default.WithVersion(3);
+
+		[EqualityKey]
+		public int Version { get; } = 1;
+	}
 }

--- a/src/Uno.CodeGen/ImmutableGenerator.cs
+++ b/src/Uno.CodeGen/ImmutableGenerator.cs
@@ -220,7 +220,10 @@ namespace Uno
 
 			(IPropertySymbol property, bool isNew)[] properties;
 
-			var typeProperties = typeSymbol.GetProperties().ToArray();
+			var typeProperties = typeSymbol
+				.GetProperties()
+				.Where(p => !p.IsStatic)
+				.ToArray();
 
 			if (baseTypeInfo.isBaseTypePresent)
 			{


### PR DESCRIPTION
from builder generation and were treated as instance properties.