### PR TITLE
Suppress CS0171 from generated partial structs

### DIFF
--- a/src/Uno.CodeGen/EqualityGenerator.cs
+++ b/src/Uno.CodeGen/EqualityGenerator.cs
@@ -288,7 +288,9 @@ namespace Uno
 					}
 					using (builder.BlockInvariant("public override int GetHashCode()"))
 					{
+						builder.AppendLineInvariant("#pragma warning disable CS0171");
 						builder.AppendLineInvariant("return _computedHashCode ?? (int)(_computedHashCode = ComputeHashCode());");
+						builder.AppendLineInvariant("#pragma warning restore CS0171");
 					}
 
 					builder.AppendLine();


### PR DESCRIPTION
A compiler error [CS0171] is reported from the `GetHashCode()` method of a generated partial struct, becuase the code tries to access `_computedHashCode` field which is uninitialized by constructors.

As the generated `_computedHashCode` is a `int?` so that it's `null` by default, it is okay to ignore [CS0171] in this case.  This patch added a `#pragma warning` block inside a generated `GetHashCode()` method, so the [CS0171] error is no more reported.

[CS0171]: https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0171