### PR TITLE
Equality - Add suport for enum types

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* Equality: You can now use `enum` as member types for `[EqualityHash]` and `[EqualityKey]`
+
 ### Breaking changes
 
 ### Bug fixes

--- a/readme.md
+++ b/readme.md
@@ -50,22 +50,12 @@ Features:
 | `ImmutableGenerator` | `[GenerateImmutable]` | Generate code to build truly immutable entities. | [Documentation](doc/Immutable%20Generation.md) |
 | `InjectableGenerator` | `[Inject]` | Generate code to resolve and inject dependencies. | [Documentation](doc/Injectable%20Generation.md) |
 
-## Continuous Integration Build status
+## Nuget
 
-| Target | Branch | Status | Recent builds | Recommended Nuget packages version |
-| ------ | ------ | ------ | ------ | ------ |
-| `development` | [master](https://github.com/nventive/Uno.CodeGen/tree/master) | [![Build status](https://ci.appveyor.com/api/projects/status/bh83u4i2lp0hrg8r/branch/master?svg=true)](https://ci.appveyor.com/project/nventivedevops/uno-codegen/branch/master) | ![Build Stats](https://buildstats.info/appveyor/chart/nventivedevops/uno-codegen?branch=master&includeBuildsFromPullRequest=false) | [![NuGet](https://buildstats.info/nuget/Uno.CodeGen?includePreReleases=true)](https://www.nuget.org/packages/Uno.CodeGen/) |
-| `stable` | [stable](https://github.com/nventive/Uno.CodeGen/tree/stable) | [![Build status](https://ci.appveyor.com/api/projects/status/bh83u4i2lp0hrg8r/branch/stable?svg=true)](https://ci.appveyor.com/project/nventivedevops/uno-codegen/branch/stable) | ![Build Stats](https://buildstats.info/appveyor/chart/nventivedevops/uno-codegen?branch=stable&includeBuildsFromPullRequest=false) | [![NuGet](https://buildstats.info/nuget/Uno.CodeGen?includePreReleases=false)](https://www.nuget.org/packages/Uno.CodeGen/) |
-
+[![NuGet](https://buildstats.info/nuget/Uno.CodeGen?includePreReleases=true)](https://www.nuget.org/packages/Uno.CodeGen/)
 
 ## FAQ
 [Read our FAQ here](doc/faq.md)
-
-## Release Notes
-
-### 1.22.0 (May 17th 2018)
-
-- Added support for System.Guid as a supported immutable type.
 
 # Have questions? Feature requests? Issues?
 

--- a/src/Uno.CodeGen.Tests/Given_GeneratedEquality.Enums.cs
+++ b/src/Uno.CodeGen.Tests/Given_GeneratedEquality.Enums.cs
@@ -1,0 +1,73 @@
+﻿// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.CodeGen.Tests
+{
+	partial class Given_GeneratedEquality
+	{
+
+		[TestMethod]
+		public void Equality_WithEnums()
+		{
+			var x1 = new MyClassWithEnums() {A = ByteEnum.No, B = SignedByteEnum.Present};
+			var x2 = new MyClassWithEnums() {A = ByteEnum.No, B = SignedByteEnum.Present};
+			var x3 = new MyClassWithEnums() {A = ByteEnum.Maybe, B = SignedByteEnum.Present};
+			var x4 = new MyClassWithEnums() {A = ByteEnum.Maybe, B = SignedByteEnum.Present};
+			var x5 = new MyClassWithEnums() {A = ByteEnum.Maybe, B = SignedByteEnum.Past};
+
+			var hash1 = x1.GetHashCode();
+			var hash2 = x2.GetHashCode();
+			var hash3 = x3.GetHashCode();
+			var hash4 = x4.GetHashCode();
+			var hash5 = x5.GetHashCode();
+
+			hash1.Should().Be(hash2);
+			hash1.Should().NotBe(hash3);
+			hash1.Should().NotBe(0);
+			hash1.Should().NotBe(104729);
+			hash3.Should().Be(hash4);
+			hash3.Should().NotBe(hash5);
+		}
+	}
+	internal enum ByteEnum : byte
+	{
+		Yes,
+		No,
+		Maybe,
+		Always,
+		Never
+	}
+
+	internal enum SignedByteEnum : sbyte
+	{
+		Past = -1,
+		Present = 0,
+		Future = 1
+	}
+
+	[GeneratedEquality]
+	internal partial class MyClassWithEnums
+	{
+		[EqualityHash]
+		internal ByteEnum A { get; set; }
+
+		[EqualityHash]
+		internal SignedByteEnum B { get; set; }
+	}
+}

--- a/src/Uno.CodeGen/EqualityGenerator.cs
+++ b/src/Uno.CodeGen/EqualityGenerator.cs
@@ -55,6 +55,7 @@ namespace Uno
 		private INamedTypeSymbol _valueTypeSymbol;
 		private INamedTypeSymbol _boolSymbol;
 		private INamedTypeSymbol _intSymbol;
+		private INamedTypeSymbol _enumSymbol;
 		private INamedTypeSymbol _arraySymbol;
 		private INamedTypeSymbol _collectionSymbol;
 		private INamedTypeSymbol _iEquatableSymbol;
@@ -108,6 +109,7 @@ namespace Uno
 			_valueTypeSymbol = context.Compilation.GetTypeByMetadataName("System.ValueType");
 			_boolSymbol = context.Compilation.GetTypeByMetadataName("System.Bool");
 			_intSymbol = context.Compilation.GetTypeByMetadataName("System.Int32");
+			_enumSymbol = context.Compilation.GetTypeByMetadataName("System.Enum");
 			_arraySymbol = context.Compilation.GetTypeByMetadataName("System.Array");
 			_collectionSymbol = context.Compilation.GetTypeByMetadataName("System.Collections.ICollection");
 			_iEquatableSymbol = context.Compilation.GetTypeByMetadataName("System.IEquatable`1");
@@ -699,6 +701,10 @@ namespace Uno
 						else if (equalityMode == KeyEqualityUseKeyEquality)
 						{
 							getHashCode = $"((global::Uno.Equality.IKeyEquatable){member.Name}).GetKeyHashCode()";
+						}
+						else if (type.BaseType == _enumSymbol)
+						{
+							getHashCode = $"{member.Name}.GetHashCode()";
 						}
 						else if (type.SpecialType == SpecialType.System_String)
 						{


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Feature
`[EqualityHash]` and `[EqualityKey]` are now supported on `enum` members.

## What is the current behavior?
Adding a member with `enum` type were producing a warning and was not used for the
calculation of the hash.

## What is the new behavior?
`enum` types can now be used as other types.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno.CodeGen/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
* <https://nventive.visualstudio.com/Umbrella/_workitems/edit/146035>