### PR TITLE
Misc fixes around indexers and readonly fields

### DIFF
--- a/doc/Immutable Generation.md
+++ b/doc/Immutable Generation.md
@@ -41,7 +41,8 @@
      `[assembly: ImmutableGenerationOptions(GenerateNewtownsoftJsonNetConverters=false)]`)
    * **No property setters allowed** (even `private` ones):
      properties should be _read only_, even for the class itself.
-   * **No fields allowed** (except static fields, but that would be weird).
+   * **No fields allowed** (except static fields, or `readonly` fields of a recognized immutable type).
+   * **No _write_ indexers** read-only indexers are ok and sometime useful for complex types.
    * **Static members are ok**, as they can only manipulate immutable stuff.
      Same apply for extensions.
    * **Nested classes not supported**, the class must be directly in its

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -5,7 +5,9 @@
 ### Features
 
 * Equality: You can now use `enum` as member types for `[EqualityHash]` and `[EqualityKey]`
+* Immutability: readonly fields are now allowed when they are of immutable types.
 
 ### Breaking changes
 
 ### Bug fixes
+* Equality: Using an indexer won't break the code generation anymore.

--- a/src/Uno.CodeGen.Tests/Given_GeneratedEquality.Indexer.cs
+++ b/src/Uno.CodeGen.Tests/Given_GeneratedEquality.Indexer.cs
@@ -1,0 +1,28 @@
+﻿// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+namespace Uno.CodeGen.Tests
+{
+	[GeneratedEquality]
+	public partial class MyEntityWithIndexer
+	{
+		public string this[string key] => null;
+	}
+
+	partial class Given_GeneratedEquality
+	{
+	}
+}

--- a/src/Uno.CodeGen.Tests/Given_ImmutableEntity.Fields.cs
+++ b/src/Uno.CodeGen.Tests/Given_ImmutableEntity.Fields.cs
@@ -1,0 +1,35 @@
+﻿// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System.Collections.Generic;
+
+namespace Uno.CodeGen.Tests
+{
+	[GeneratedImmutable]
+	internal partial class MyEntityWithFields
+	{
+		private readonly IReadOnlyDictionary<string, string> _readonlyField;
+
+		public MyEntityWithFields(IReadOnlyDictionary<string, string> readonlyField)
+		{
+			_readonlyField = readonlyField;
+		}
+	}
+
+	partial class Given_ImmutableEntity
+	{
+	}
+}

--- a/src/Uno.CodeGen/EqualityGenerator.cs
+++ b/src/Uno.CodeGen/EqualityGenerator.cs
@@ -813,6 +813,7 @@ namespace Uno
 				where !property.IsStatic
 				where !property.IsImplicitlyDeclared
 				where property.GetMethod.DeclaredAccessibility > Accessibility.Private
+				where !property.IsIndexer
 				select (symbol: (ISymbol)property, type: property.Type);
 
 			var fields =

--- a/src/Uno.CodeGen/ImmutableGenerator.cs
+++ b/src/Uno.CodeGen/ImmutableGenerator.cs
@@ -951,10 +951,17 @@ $@"public sealed class {symbolName}BuilderJsonConverterTo{symbolName}{genericArg
 
 				if (!field.IsStatic)
 				{
-					Error(
-						builder,
-						$"Immutable type {symbolNames.SymbolNameWithGenerics} cannot "
-						+ $"have the non-static field {field.Name}. You must remove it for immutable generation or make it static.");
+					if (field.IsReadOnly)
+					{
+						CheckTypeImmutable(field.Type, $"Field {field.Name}");
+					}
+					else
+					{
+						Error(
+							builder,
+							$"Immutable type {symbolNames.SymbolNameWithGenerics} cannot "
+							+ $"have the non-static field {field.Name}. You must either remove it, make it readonly or static to allow for immutable generation.");
+					}
 				}
 			}
 		}

--- a/src/Uno.CodeGen/ImmutableGenerator.cs
+++ b/src/Uno.CodeGen/ImmutableGenerator.cs
@@ -954,7 +954,7 @@ $@"public sealed class {symbolName}BuilderJsonConverterTo{symbolName}{genericArg
 					Error(
 						builder,
 						$"Immutable type {symbolNames.SymbolNameWithGenerics} cannot "
-						+ "have the non-static field {field.Name}. You must remove it for immutable generation or make it static.");
+						+ $"have the non-static field {field.Name}. You must remove it for immutable generation or make it static.");
 				}
 			}
 		}
@@ -1011,15 +1011,15 @@ $@"public sealed class {symbolName}BuilderJsonConverterTo{symbolName}{genericArg
 		private void Warning(IIndentedStringBuilder builder, string warningMsg)
 		{
 			var msg = $"{nameof(ImmutableGenerator)}/{_currentType}: {warningMsg}";
-			builder.AppendLineInvariant("#warning " + msg.Replace('\n', ' ').Replace('\r', ' '));
 			_logger.Warn(msg);
+			builder.AppendLineInvariant("#warning " + msg.Replace('\n', ' ').Replace('\r', ' '));
 		}
 
 		private void Error(IIndentedStringBuilder builder, string warningMsg)
 		{
 			var msg = $"{nameof(ImmutableGenerator)}/{_currentType}: {warningMsg}";
-			builder.AppendLineInvariant("#error " + msg.Replace('\n', ' ').Replace('\r', ' '));
 			_logger.Error(msg);
+			builder.AppendLineInvariant("#error " + msg.Replace('\n', ' ').Replace('\r', ' '));
 		}
 	}
 }


### PR DESCRIPTION
## Bug fixes
* Equality: read _indexers_ where used by default for equality members generation.
  They are now ommitted from generation.
* Immutability: it is now possible to have an instance field when it's both `readonly` and
  of a recognized immutable type.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.CodeGen/tree/master/doc/.feature-template.md). (for bug fixes / features)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno.CodeGen/tree/master/doc/ReleaseNotes)
