### PR TITLE
Add Uno.MonoAnalyzers to prevent using string APIs introduced in 15.9 and later

### DIFF
--- a/src/Uno.ClassLifecycle/Uno.ClassLifecycle.csproj
+++ b/src/Uno.ClassLifecycle/Uno.ClassLifecycle.csproj
@@ -21,4 +21,11 @@ This package is part of the Uno.CodeGen to generate object life cycle methods in
 	</PropertyGroup>
 
 	<Import Project="..\Uno.Common.props" />
+
+	<ItemGroup>
+	  <PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
 </Project>

--- a/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
+++ b/src/Uno.CodeGen.ClassLifecycle/Uno.CodeGen.ClassLifecycle.csproj
@@ -29,6 +29,10 @@ This package is part of the Uno.CodeGen to generate classes lifecycle methods in
 	</ItemGroup>
 	
 	<ItemGroup>
+		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="1.30.0-dev.245" PrivateAssets="none">
 		  <NoWarn>NU1701</NoWarn>
 		</PackageReference>

--- a/src/Uno.CodeGen.Tests.ExternalClasses/Uno.CodeGen.Tests.ExternalClasses.csproj
+++ b/src/Uno.CodeGen.Tests.ExternalClasses/Uno.CodeGen.Tests.ExternalClasses.csproj
@@ -13,6 +13,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="Uno.SourceGenerationTasks" Version="1.30.0-dev.245" />
 	</ItemGroup>
 

--- a/src/Uno.CodeGen.Tests/Uno.CodeGen.Tests.csproj
+++ b/src/Uno.CodeGen.Tests/Uno.CodeGen.Tests.csproj
@@ -21,6 +21,10 @@
 		<PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
 		<PackageReference Include="Uno.Core" Version="1.27.0-dev.65" />
+		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 	  <PackageReference Include="Uno.SourceGenerationTasks" Version="1.30.0-dev.245">
 		  <NoWarn>NU1701</NoWarn>
 

--- a/src/Uno.CodeGen/Uno.CodeGen.csproj
+++ b/src/Uno.CodeGen/Uno.CodeGen.csproj
@@ -26,6 +26,10 @@
 
   <ItemGroup>
 	<PackageReference Include="Microsoft.CodeAnalysis" Version="2.3.0" PrivateAssets="all" />
+	<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+	  <PrivateAssets>all</PrivateAssets>
+	  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	</PackageReference>
 	<PackageReference Include="Uno.SourceGenerationTasks" Version="1.30.0-dev.245" PrivateAssets="none">
 		<NoWarn>NU1701</NoWarn>
 	</PackageReference>

--- a/src/Uno.Equality/Uno.Equality.csproj
+++ b/src/Uno.Equality/Uno.Equality.csproj
@@ -22,4 +22,11 @@ This package is part of the Uno.CodeGen to generate equality members in your pro
 	
 	<Import Project="..\Uno.Common.props" />
 	
+	<ItemGroup>
+	  <PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
+	
 </Project>

--- a/src/Uno.Immutables/Uno.Immutables.csproj
+++ b/src/Uno.Immutables/Uno.Immutables.csproj
@@ -24,6 +24,10 @@ This package is part of the Uno.CodeGen to generate immutable entities in your p
 	
 	<ItemGroup>
 	  <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
+	  <PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Injectable/Uno.Injectable.csproj
+++ b/src/Uno.Injectable/Uno.Injectable.csproj
@@ -21,5 +21,12 @@ This package is part of the Uno.CodeGen to generate injectable entities in your 
 	</PropertyGroup>
 	
 	<Import Project="..\Uno.Common.props" />
+	
+	<ItemGroup>
+	  <PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add Uno.MonoAnalyzers to prevent using string APIs introduced in 15.9 and later