### PR TITLE
fixed gitversion

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -1,7 +1,6 @@
 #addin "Cake.FileHelpers"
 #addin "Cake.Powershell"
-#tool "nuget:?package=GitVersion.CommandLine"
-#tool "nuget:?package=GitVersion.CommandLine&version=3.6.5"
+#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 
 using System;
 using System.Linq;

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -4,18 +4,30 @@ next-version: 1.33.0
 continuous-delivery-fallback-tag: ""
 branches:
   master:
+    regex: master
     tag: dev
     increment: none
   beta:
-    tag: beta
+    regex: release/beta/
+    tag: 'beta'
     increment: none
-  (stable):
-    tag: 
+    source-branches: ['master']
+  stable:
+    regex: release/stable/
+    tag: ''
     increment: none
-  dev/.*?/(.*?):
+    source-branches: ['master']
+  dev:
+    regex: dev/.*?/(.*?)
     tag: dev.{BranchName}
-  projects/(.*?):
+    source-branches: ['master']
+  projects:
     tag: proj-{BranchName}
-    increment: none
+    regex: projects/(.*?)
+    source-branches: ['master']
+  feature:
+    tag: feature.{BranchName}
+    regex: feature/(.*?)
+    source-branches: ['master']
 ignore:
   sha: []


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
`gitversion` calculates the version for `release/stable` branches as if they are "beta".

## What is the new behavior?
`gitversion` should now gives the correct version for each branch.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

## Other information
See: https://github.com/nventive/Uno.Core/pull/54

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/157370